### PR TITLE
Check Pagerando for incompatible/required compiler options

### DIFF
--- a/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/include/clang/Basic/DiagnosticDriverKinds.td
@@ -255,6 +255,9 @@ def warn_slash_u_filename : Warning<"'/U%0' treated as the '/U' option">,
   InGroup<DiagGroup<"slash-u-filename">>;
 def note_use_dashdash : Note<"Use '--' to treat subsequent arguments as filenames">;
 
+def err_drv_pagerando_incompatible_with_separate_sections : Error<
+  "Pagerando and separate sections ('-ffunction-sections', '-fdata-sections') are incompatible">;
+
 def err_drv_ropi_rwpi_incompatible_with_pic : Error<
   "embedded and GOT-based position independence are incompatible">;
 def err_drv_ropi_incompatible_with_cxx : Error<

--- a/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/include/clang/Basic/DiagnosticDriverKinds.td
@@ -257,6 +257,8 @@ def note_use_dashdash : Note<"Use '--' to treat subsequent arguments as filename
 
 def err_drv_pagerando_incompatible_with_separate_sections : Error<
   "Pagerando and separate sections ('-ffunction-sections', '-fdata-sections') are incompatible">;
+def err_drv_pagerando_requires_lto : Error<
+  "Pagerando requires link time optimization ('-flto')">;
 
 def err_drv_ropi_rwpi_incompatible_with_pic : Error<
   "embedded and GOT-based position independence are incompatible">;

--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -877,10 +877,9 @@ tools::ParsePICArgs(const ToolChain &ToolChain, const ArgList &Args) {
   bool DataSection = Args.hasFlag(options::OPT_fdata_sections,
                                   options::OPT_fno_data_sections,
                                   UseSeparateSections);
-  if (PIP && (FunctionSections || DataSection)) {
-    ToolChain.getDriver().Diag(diag::err_drv_argument_not_allowed_with)
-        << LastPIPArg->getSpelling() << "separate function or data sections";
-  }
+  if (PIP && (FunctionSections || DataSection))
+    ToolChain.getDriver().Diag(
+        diag::err_drv_pagerando_incompatible_with_separate_sections);
 
   // ROPI and RWPI are not comaptible with PIC or PIE.
   if ((ROPI || RWPI) && (PIC || PIE))

--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -870,6 +870,18 @@ tools::ParsePICArgs(const ToolChain &ToolChain, const ArgList &Args) {
     PIP = true;
   }
 
+  bool UseSeparateSections = isUseSeparateSections(Triple);
+  bool FunctionSections = Args.hasFlag(options::OPT_ffunction_sections,
+                                       options::OPT_fno_function_sections,
+                                       UseSeparateSections);
+  bool DataSection = Args.hasFlag(options::OPT_fdata_sections,
+                                  options::OPT_fno_data_sections,
+                                  UseSeparateSections);
+  if (PIP && (FunctionSections || DataSection)) {
+    ToolChain.getDriver().Diag(diag::err_drv_argument_not_allowed_with)
+        << LastPIPArg->getSpelling() << "separate function or data sections";
+  }
+
   // ROPI and RWPI are not comaptible with PIC or PIE.
   if ((ROPI || RWPI) && (PIC || PIE))
     ToolChain.getDriver().Diag(diag::err_drv_ropi_rwpi_incompatible_with_pic);

--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -871,7 +871,7 @@ tools::ParsePICArgs(const ToolChain &ToolChain, const ArgList &Args) {
   }
 
   // Pagerando and '-ffunction-sections'/'-fdata-sections' are incompatible
-  bool UseSeparateSections = isUseSeparateSections(Triple);
+  bool UseSeparateSections = isUseSeparateSections(EffectiveTriple);
   bool FunctionSections = Args.hasFlag(options::OPT_ffunction_sections,
                                        options::OPT_fno_function_sections,
                                        UseSeparateSections);

--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -870,6 +870,7 @@ tools::ParsePICArgs(const ToolChain &ToolChain, const ArgList &Args) {
     PIP = true;
   }
 
+  // Pagerando and '-ffunction-sections'/'-fdata-sections' are incompatible
   bool UseSeparateSections = isUseSeparateSections(Triple);
   bool FunctionSections = Args.hasFlag(options::OPT_ffunction_sections,
                                        options::OPT_fno_function_sections,
@@ -880,6 +881,7 @@ tools::ParsePICArgs(const ToolChain &ToolChain, const ArgList &Args) {
   if (PIP && (FunctionSections || DataSection))
     ToolChain.getDriver().Diag(
         diag::err_drv_pagerando_incompatible_with_separate_sections);
+  // Pagerando requires '-flto'
   if (PIP && !ToolChain.getDriver().isUsingLTO())
     ToolChain.getDriver().Diag(diag::err_drv_pagerando_requires_lto);
 

--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -880,6 +880,8 @@ tools::ParsePICArgs(const ToolChain &ToolChain, const ArgList &Args) {
   if (PIP && (FunctionSections || DataSection))
     ToolChain.getDriver().Diag(
         diag::err_drv_pagerando_incompatible_with_separate_sections);
+  if (PIP && !ToolChain.getDriver().isUsingLTO())
+    ToolChain.getDriver().Diag(diag::err_drv_pagerando_requires_lto);
 
   // ROPI and RWPI are not comaptible with PIC or PIE.
   if ((ROPI || RWPI) && (PIC || PIE))

--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -882,7 +882,7 @@ tools::ParsePICArgs(const ToolChain &ToolChain, const ArgList &Args) {
     ToolChain.getDriver().Diag(
         diag::err_drv_pagerando_incompatible_with_separate_sections);
   // Pagerando requires '-flto'
-  if (PIP && !ToolChain.getDriver().isUsingLTO())
+  if (PIP && ToolChain.getDriver().getLTOMode() != LTOK_Full)
     ToolChain.getDriver().Diag(diag::err_drv_pagerando_requires_lto);
 
   // ROPI and RWPI are not comaptible with PIC or PIE.


### PR DESCRIPTION
Are the checks added in a natural place?
Checks seem a bit clumsy (duplicated code), but I couldn't find a more streamlined way.

This enables us to add an assert in the back end and get rid of the special RandText section kind.