### PR TITLE
Rename compiler flag '-fpip' -> '-fpagerando'

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -1296,8 +1296,8 @@ def fropi : Flag<["-"], "fropi">, Group<f_Group>;
 def fno_ropi : Flag<["-"], "fno-ropi">, Group<f_Group>;
 def frwpi : Flag<["-"], "frwpi">, Group<f_Group>;
 def fno_rwpi : Flag<["-"], "fno-rwpi">, Group<f_Group>;
-def fpip : Flag<["-"], "fpip">, Group<f_Group>;
-def fno_pip : Flag<["-"], "fno-pip">, Group<f_Group>;
+def fpagerando : Flag<["-"], "fpagerando">, Group<f_Group>;
+def fno_pagerando : Flag<["-"], "fno-pagerando">, Group<f_Group>;
 def fplugin_EQ : Joined<["-"], "fplugin=">, Group<f_Group>, Flags<[DriverOption]>, MetaVarName<"<dsopath>">,
   HelpText<"Load the named plugin (dynamic shared object)">;
 def fpreserve_as_comments : Flag<["-"], "fpreserve-as-comments">, Group<f_Group>;

--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -862,8 +862,9 @@ tools::ParsePICArgs(const ToolChain &ToolChain, const ArgList &Args) {
           << LastRWPIArg->getSpelling() << Triple.str();
     RWPI = true;
   }
-  Arg *LastPIPArg = Args.getLastArg(options::OPT_fpip, options::OPT_fno_pip);
-  if (LastPIPArg && LastPIPArg->getOption().matches(options::OPT_fpip)) {
+  Arg *LastPIPArg = Args.getLastArg(options::OPT_fpagerando,
+                                    options::OPT_fno_pagerando);
+  if (LastPIPArg && LastPIPArg->getOption().matches(options::OPT_fpagerando)) {
     if (!EmbeddedPISupported && Triple.getArch() != llvm::Triple::aarch64)
       ToolChain.getDriver().Diag(diag::err_drv_unsupported_opt_for_target)
           << LastPIPArg->getSpelling() << Triple.str();


### PR DESCRIPTION
Affects the following:
immunant/android_build_make#1
immunant/android_build_soong#1
immunant/testsuite#10

Hold out on renaming `PIP` relocation model; we don't know yet if a separate relocation model is the way to go. Also hold out renaming linker plugin flag.